### PR TITLE
IMP-1: update the logic on path creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ cython_debug/
 #.idea/
 
 torrent/
+config.json


### PR DESCRIPTION
新增读取番剧名称的HTTP访问

路径创建逻辑由按种子发布日期分类改为根据番剧名称分类
- 提高pikpak网盘文件夹的可读性和可维护性
- 提高本地种子文件的可读性和可维护性

优化部分代码的可读性

略微重构download_torrent和check_torrent以遵循单一职责原则

mylist从局部变量改为全局变量，减少解析RSS造成的HTTP访问

原文件夹创建例:
![image](https://github.com/user-attachments/assets/90bd6937-d2aa-4128-8814-de96ebf4e72e)

变更后的文件夹创建例:
![image](https://github.com/user-attachments/assets/13d9b34e-62d3-4e03-ad24-9b6231d18e45)

